### PR TITLE
Removed dev import logic from multimech-run

### DIFF
--- a/multimechanize/utilities/run.py
+++ b/multimechanize/utilities/run.py
@@ -5,33 +5,20 @@
 #
 #  This file is part of Multi-Mechanize | Performance Test Framework
 #
-
-
-
 import ConfigParser
 import multiprocessing
 import optparse
 import os
-import Queue
 import shutil
 import subprocess
 import sys
 import time
 
-try:
-    # installed
-    import multimechanize
-except ImportError:
-    # from dev/source
-    this_dir = os.path.abspath(os.path.dirname(__file__))
-    sys.path.append(os.path.join(this_dir, '../../'))
-    import multimechanize
-
 import multimechanize.core as core
 import multimechanize.results as results
 import multimechanize.resultswriter as resultswriter
 import multimechanize.progressbar as progressbar
-    
+
 
 usage = 'Usage: %prog <project name> [options]'
 parser = optparse.OptionParser(usage=usage)


### PR DESCRIPTION
This logic isn't needed as you can achieve the same thing easily with pip:
1. Make a git clone of the repo
2. Inside a virtualenv and from the clone's root, run `pip install -e .`

This allows you to edit and run the cloned copy of multi-mechanize.

Also, the import itself isn't needed at all because it's never used in the code that follows.
