### PR TITLE
Do not record line breaks in results csv file.

### DIFF
--- a/multimechanize/resultswriter.py
+++ b/multimechanize/resultswriter.py
@@ -40,6 +40,9 @@ class ResultsWriter(threading.Thread):
                     self.trans_count += 1
                     self.timer_count += len(custom_timers)
                     if error != '':
+                        # Convert line breaks to literal \n so the CSV will be readable.
+                        error = '\\n'.join(error.splitlines())
+
                         self.error_count += 1
                     f.write('%i,%.3f,%i,%s,%f,%s,%s\n' % (self.trans_count, elapsed, epoch, self.user_group_name, scriptrun_time, error, repr(custom_timers)))
                     f.flush()


### PR DESCRIPTION
The csv file becomes unreadable when the error text includes line breaks. This pull request converts those line breaks to literal \n characters.
