### PR TITLE
add user group processes config entry

### DIFF
--- a/examples/config.cfg
+++ b/examples/config.cfg
@@ -10,8 +10,10 @@ xml_report = off
 
 [user_group-1]
 threads = 3
+processes = 4
 script = example_mock.py
 
 [user_group-2]
 threads = 3
+processes = 2
 script = example_mock.py

--- a/multimechanize/results.py
+++ b/multimechanize/results.py
@@ -46,10 +46,10 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
     if user_group_configs:
         report.write_line('<b>workload configuration:</b><br /><br />')
         report.write_line('<table>')
-        report.write_line('<tr><th>group name</th><th>threads</th><th>script name</th></tr>')
+        report.write_line('<tr><th>group name</th><th>processes</th><th>threads</th><th>script name</th></tr>')
         for user_group_config in user_group_configs:
-            report.write_line('<tr><td>%s</td><td>%d</td><td>%s</td></tr>' %
-                (user_group_config.name, user_group_config.num_threads, user_group_config.script_file))
+            report.write_line('<tr><td>%s</td><td>%d</td><td>%d</td><td>%s</td></tr>' %
+                (user_group_config.name, user_group_config.num_processes, user_group_config.num_threads, user_group_config.script_file))
         report.write_line('</table>')
     report.write_line('</div>')
 

--- a/multimechanize/resultsloader.py
+++ b/multimechanize/resultsloader.py
@@ -54,17 +54,19 @@ class UserGroupConfig(Base):
     id = Column (Integer, nullable=False, primary_key=True)
     mechanize_global_configs_id = Column(Integer, ForeignKey('mechanize_global_configs.id'), nullable=False)
     user_group = Column(String(50), nullable=False)
+    processes = Column(Integer, nullable=False)
     threads = Column(Integer, nullable=False)
     script = Column(String(50), nullable=False)
 
-    def __init__(self, user_group=None, threads=None, script=None):
+    def __init__(self, user_group=None, processes=None, threads=None, script=None):
         self.user_group = str(user_group)
+        self.processes = int(processes)
         self.threads = int(threads)
         self.script = str(script)
 
     def __repr__(self):
-        return "<UserGroupConfig('%s','%s','%s')>" % (
-                self.user_group, self.threads, self.script)
+        return "<UserGroupConfig('%s','%i', '%i','%s')>" % (
+                self.user_group, self.processes, self.threads, self.script)
 
 class ResultRow(Base):
     """class representing a multi-mechanize results.csv row"""
@@ -157,7 +159,7 @@ def load_results_database(project_name, run_localtime, results_dir,
 
     for i, ug_config in enumerate(user_group_configs):
         user_group_config = UserGroupConfig(ug_config.name,
-                ug_config.num_threads, ug_config.script_file)
+                ug_config.num_processes, ug_config.num_threads, ug_config.script_file)
         global_config.user_group_configs.append(user_group_config)
 
     for line in fileinput.input([results_file]):

--- a/multimechanize/utilities/newproject.py
+++ b/multimechanize/utilities/newproject.py
@@ -28,10 +28,12 @@ xml_report = off
 
 [user_group-1]
 threads = 3
+processes = 4
 script = %s
 
 [user_group-2]
 threads = 3
+processes = 2
 script = %s
 
 """ % (SCRIPT_NAME, SCRIPT_NAME)


### PR DESCRIPTION
when I use this framework to test our site I find out that it's not convenient to specify processes. So we want a configuration way to specify the amount of processes of a user group. This pull request is a way to add a config entry to the config.cfg file. In this pull request we can do this:

```
[user_group-1]
threads = 3
processes = 4
script = example_mock.py
```

the `processes` specifies that it has four processes for user_group-1 and each process has three threads to run. it  equals to this:

```
[user_group-1] 
threads = 3
script = example_mock.py

[user_group-2] 
threads = 3
script = example_mock.py

[user_group-3] 
threads = 3
script = example_mock.py

[user_group-4] 
threads = 3
script = example_mock.py
```

it's so tedious to do the duplicate works.

the `processes` entry is optional, if not specified, default value is 1 

thx
