### PR TITLE
Call user_group.run() instead of start when on Windows

### DIFF
--- a/multimechanize/utilities/run.py
+++ b/multimechanize/utilities/run.py
@@ -95,7 +95,7 @@ def run_test(project_name, cmd_opts, remote_starter=None):
                             script_file, run_time, rampup)
         user_groups.append(ug)
     for user_group in user_groups:
-        if sys.platform == 'win32':
+        if sys.platform.startswith('win'):
             user_group.run()
         else:
             user_group.start()


### PR DESCRIPTION
Fix for #19 to allow process to run without errors on Windows.
