### PR TITLE
Reset timers after each run.

### DIFF
--- a/multimechanize/core.py
+++ b/multimechanize/core.py
@@ -96,7 +96,6 @@ class Agent(threading.Thread):
     def run(self):
         elapsed = 0
         trans = self.script_module.Transaction()
-        trans.custom_timers = {}
 
         # scripts have access to these vars, which can be useful for loading unique data
         trans.thread_num = self.thread_num
@@ -104,6 +103,7 @@ class Agent(threading.Thread):
 
         while elapsed < self.run_time:
             error = ''
+            trans.custom_timers = {}
             start = self.default_timer()
 
             try:


### PR DESCRIPTION
My reason for this was, I'm testing a load balanced service, and was setting the key of the custom_timer to the X-Handled-By header.  So any given Test would only have one of N timers set.  But the old timers were cluttering my results.
