### PR TITLE
Fix to writer fails with IndexError: list index out of range where timer has fired after the test has finished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 .tox
 /.idea
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build
 build
 dist
 .tox
+/.idea

--- a/multimechanize/results.py
+++ b/multimechanize/results.py
@@ -9,13 +9,14 @@
 
 import time
 from collections import defaultdict
+
 import graph
 import reportwriter
 import reportwriterxml
 
 
-
-def output_results(results_dir, results_file, run_time, rampup, ts_interval, user_group_configs=None, xml_reports=False):
+def output_results(results_dir, results_file, run_time, rampup, ts_interval, user_group_configs=None,
+                   xml_reports=False):
     results = Results(results_dir + results_file, run_time)
 
     report = reportwriter.Report(results_dir)
@@ -49,7 +50,7 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
         report.write_line('<tr><th>group name</th><th>threads</th><th>script name</th></tr>')
         for user_group_config in user_group_configs:
             report.write_line('<tr><td>%s</td><td>%d</td><td>%s</td></tr>' %
-                (user_group_config.name, user_group_config.num_threads, user_group_config.script_file))
+                              (user_group_config.name, user_group_config.num_threads, user_group_config.script_file))
         report.write_line('</table>')
     report.write_line('</div>')
 
@@ -66,19 +67,20 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
 
     report.write_line('<h3>Transaction Response Summary (secs)</h3>')
     report.write_line('<table>')
-    report.write_line('<tr><th>count</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
-    report.write_line('<tr><td>%i</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>'  % (
-        results.total_transactions,
-        min(trans_timer_vals),
-        average(trans_timer_vals),
-        percentile(trans_timer_vals, 80),
-        percentile(trans_timer_vals, 90),
-        percentile(trans_timer_vals, 95),
-        max(trans_timer_vals),
-        standard_dev(trans_timer_vals),
-    ))
+    report.write_line(
+        '<tr><th>count</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
+    report.write_line(
+        '<tr><td>%i</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>' % (
+            results.total_transactions,
+            min(trans_timer_vals),
+            average(trans_timer_vals),
+            percentile(trans_timer_vals, 80),
+            percentile(trans_timer_vals, 90),
+            percentile(trans_timer_vals, 95),
+            max(trans_timer_vals),
+            standard_dev(trans_timer_vals),
+        ))
     report.write_line('</table>')
-
 
     # all transactions - interval details
     avg_resptime_points = {}  # {intervalnumber: avg_resptime}
@@ -88,13 +90,16 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
     splat_series = split_series(trans_timer_points, interval_secs)
     report.write_line('<h3>Interval Details (secs)</h3>')
     report.write_line('<table>')
-    report.write_line('<tr><th>interval</th><th>count</th><th>rate</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
+    report.write_line(
+        '<tr><th>interval</th><th>count</th><th>rate</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
     for i, bucket in enumerate(splat_series):
         interval_start = int((i + 1) * interval_secs)
         cnt = len(bucket)
 
         if cnt == 0:
-            report.write_line('<tr><td>%i</td><td>0</td><td>0</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td></tr>' % (i + 1))
+            report.write_line(
+                '<tr><td>%i</td><td>0</td><td>0</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td></tr>' % (
+                    i + 1))
         else:
             rate = cnt / float(interval_secs)
             mn = min(bucket)
@@ -104,15 +109,17 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
             pct_95 = percentile(bucket, 95)
             mx = max(bucket)
             stdev = standard_dev(bucket)
-            report.write_line('<tr><td>%i</td><td>%i</td><td>%.2f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>' % (i + 1, cnt, rate, mn, avg, pct_80, pct_90, pct_95, mx, stdev))
+            report.write_line(
+                '<tr><td>%i</td><td>%i</td><td>%.2f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>' % (
+                    i + 1, cnt, rate, mn, avg, pct_80, pct_90, pct_95, mx, stdev))
 
             avg_resptime_points[interval_start] = avg
             percentile_80_resptime_points[interval_start] = pct_80
             percentile_90_resptime_points[interval_start] = pct_90
 
     report.write_line('</table>')
-    graph.resp_graph(avg_resptime_points, percentile_80_resptime_points, percentile_90_resptime_points, 'All_Transactions_response_times_intervals.png', results_dir)
-
+    graph.resp_graph(avg_resptime_points, percentile_80_resptime_points, percentile_90_resptime_points,
+                     'All_Transactions_response_times_intervals.png', results_dir)
 
     report.write_line('<h3>Graphs</h3>')
     report.write_line('<h4>Response Time: %s sec time-series</h4>' % ts_interval)
@@ -122,8 +129,6 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
     report.write_line('<h4>Throughput: 5 sec time-series</h4>')
     report.write_line('<img src="All_Transactions_throughput.png"></img>')
 
-
-
     # all transactions - throughput
     throughput_points = {}  # {intervalnumber: numberofrequests}
     interval_secs = ts_interval
@@ -131,8 +136,6 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
     for i, bucket in enumerate(splat_series):
         throughput_points[int((i + 1) * interval_secs)] = (len(bucket) / interval_secs)
     graph.tp_graph(throughput_points, 'All_Transactions_throughput.png', results_dir)
-
-
 
     # custom timers
     for timer_name in sorted(results.uniq_timer_names):
@@ -145,81 +148,87 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
                 custom_timer_vals.append(val)
             except KeyError:
                 pass
-        graph.resp_graph_raw(custom_timer_points, timer_name + '_response_times.png', results_dir)
+        if len(custom_timer_points) > 0:
 
-        throughput_points = {}  # {intervalnumber: numberofrequests}
-        interval_secs = ts_interval
-        splat_series = split_series(custom_timer_points, interval_secs)
-        for i, bucket in enumerate(splat_series):
-            throughput_points[int((i + 1) * interval_secs)] = (len(bucket) / interval_secs)
-        graph.tp_graph(throughput_points, timer_name + '_throughput.png', results_dir)
+            graph.resp_graph_raw(custom_timer_points, timer_name + '_response_times.png', results_dir)
 
-        report.write_line('<hr />')
-        report.write_line('<h2>Custom Timer: %s</h2>' % timer_name)
+            throughput_points = {}  # {intervalnumber: numberofrequests}
+            interval_secs = ts_interval
+            splat_series = split_series(custom_timer_points, interval_secs)
+            for i, bucket in enumerate(splat_series):
+                throughput_points[int((i + 1) * interval_secs)] = (len(bucket) / interval_secs)
+            graph.tp_graph(throughput_points, timer_name + '_throughput.png', results_dir)
 
-        report.write_line('<h3>Timer Summary (secs)</h3>')
+            report.write_line('<hr />')
+            report.write_line('<h2>Custom Timer: %s</h2>' % timer_name)
 
-        report.write_line('<table>')
-        report.write_line('<tr><th>count</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
-        report.write_line('<tr><td>%i</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>'  % (
-            len(custom_timer_vals),
-            min(custom_timer_vals),
-            average(custom_timer_vals),
-            percentile(custom_timer_vals, 80),
-            percentile(custom_timer_vals, 90),
-            percentile(custom_timer_vals, 95),
-            max(custom_timer_vals),
-            standard_dev(custom_timer_vals)
-        ))
-        report.write_line('</table>')
+            report.write_line('<h3>Timer Summary (secs)</h3>')
 
+            report.write_line('<table>')
+            report.write_line(
+                '<tr><th>count</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
+            report.write_line(
+                '<tr><td>%i</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>' % (
+                    len(custom_timer_vals),
+                    min(custom_timer_vals),
+                    average(custom_timer_vals),
+                    percentile(custom_timer_vals, 80),
+                    percentile(custom_timer_vals, 90),
+                    percentile(custom_timer_vals, 95),
+                    max(custom_timer_vals),
+                    standard_dev(custom_timer_vals)
+                ))
+            report.write_line('</table>')
 
-        # custom timers - interval details
-        avg_resptime_points = {}  # {intervalnumber: avg_resptime}
-        percentile_80_resptime_points = {}  # {intervalnumber: 80pct_resptime}
-        percentile_90_resptime_points = {}  # {intervalnumber: 90pct_resptime}
-        interval_secs = ts_interval
-        splat_series = split_series(custom_timer_points, interval_secs)
-        report.write_line('<h3>Interval Details (secs)</h3>')
-        report.write_line('<table>')
-        report.write_line('<tr><th>interval</th><th>count</th><th>rate</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
-        for i, bucket in enumerate(splat_series):
-            interval_start = int((i + 1) * interval_secs)
-            cnt = len(bucket)
+            # custom timers - interval details
+            avg_resptime_points = {}  # {intervalnumber: avg_resptime}
+            percentile_80_resptime_points = {}  # {intervalnumber: 80pct_resptime}
+            percentile_90_resptime_points = {}  # {intervalnumber: 90pct_resptime}
+            interval_secs = ts_interval
+            splat_series = split_series(custom_timer_points, interval_secs)
+            report.write_line('<h3>Interval Details (secs)</h3>')
+            report.write_line('<table>')
+            report.write_line(
+                '<tr><th>interval</th><th>count</th><th>rate</th><th>min</th><th>avg</th><th>80pct</th><th>90pct</th><th>95pct</th><th>max</th><th>stdev</th></tr>')
+            for i, bucket in enumerate(splat_series):
+                interval_start = int((i + 1) * interval_secs)
+                cnt = len(bucket)
 
-            if cnt == 0:
-                report.write_line('<tr><td>%i</td><td>0</td><td>0</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td></tr>' % (i + 1))
-            else:
-                rate = cnt / float(interval_secs)
-                mn = min(bucket)
-                avg = average(bucket)
-                pct_80 = percentile(bucket, 80)
-                pct_90 = percentile(bucket, 90)
-                pct_95 = percentile(bucket, 95)
-                mx = max(bucket)
-                stdev = standard_dev(bucket)
+                if cnt == 0:
+                    report.write_line(
+                        '<tr><td>%i</td><td>0</td><td>0</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td></tr>' % (
+                            i + 1))
+                else:
+                    rate = cnt / float(interval_secs)
+                    mn = min(bucket)
+                    avg = average(bucket)
+                    pct_80 = percentile(bucket, 80)
+                    pct_90 = percentile(bucket, 90)
+                    pct_95 = percentile(bucket, 95)
+                    mx = max(bucket)
+                    stdev = standard_dev(bucket)
 
-                report.write_line('<tr><td>%i</td><td>%i</td><td>%.2f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>' % (i + 1, cnt, rate, mn, avg, pct_80, pct_90, pct_95, mx, stdev))
+                    report.write_line(
+                        '<tr><td>%i</td><td>%i</td><td>%.2f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td><td>%.3f</td></tr>' % (
+                            i + 1, cnt, rate, mn, avg, pct_80, pct_90, pct_95, mx, stdev))
 
-                avg_resptime_points[interval_start] = avg
-                percentile_80_resptime_points[interval_start] = pct_80
-                percentile_90_resptime_points[interval_start] = pct_90
-        report.write_line('</table>')
-        graph.resp_graph(avg_resptime_points, percentile_80_resptime_points, percentile_90_resptime_points, timer_name + '_response_times_intervals.png', results_dir)
+                    avg_resptime_points[interval_start] = avg
+                    percentile_80_resptime_points[interval_start] = pct_80
+                    percentile_90_resptime_points[interval_start] = pct_90
+            report.write_line('</table>')
+            graph.resp_graph(avg_resptime_points, percentile_80_resptime_points, percentile_90_resptime_points,
+                             timer_name + '_response_times_intervals.png', results_dir)
 
-
-        report.write_line('<h3>Graphs</h3>')
-        report.write_line('<h4>Response Time: %s sec time-series</h4>' % ts_interval)
-        report.write_line('<img src="%s_response_times_intervals.png"></img>' % timer_name)
-        report.write_line('<h4>Response Time: raw data (all points)</h4>')
-        report.write_line('<img src="%s_response_times.png"></img>' % timer_name)
-        report.write_line('<h4>Throughput: %s sec time-series</h4>' % ts_interval)
-        report.write_line('<img src="%s_throughput.png"></img>' % timer_name)
-
-
+            report.write_line('<h3>Graphs</h3>')
+            report.write_line('<h4>Response Time: %s sec time-series</h4>' % ts_interval)
+            report.write_line('<img src="%s_response_times_intervals.png"></img>' % timer_name)
+            report.write_line('<h4>Response Time: raw data (all points)</h4>')
+            report.write_line('<img src="%s_response_times.png"></img>' % timer_name)
+            report.write_line('<h4>Throughput: %s sec time-series</h4>' % ts_interval)
+            report.write_line('<img src="%s_throughput.png"></img>' % timer_name)
 
     ## user group times
-    #for user_group_name in sorted(results.uniq_user_group_names):
+    # for user_group_name in sorted(results.uniq_user_group_names):
     #    ug_timer_vals = []
     #    for resp_stats in results.resp_stats_list:
     #        if resp_stats.user_group_name == user_group_name:
@@ -237,8 +246,6 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
     report.write_closing_html()
 
 
-
-
 class Results(object):
     def __init__(self, results_file_name, run_time):
         self.results_file_name = results_file_name
@@ -254,8 +261,6 @@ class Results(object):
         self.epoch_finish = self.resp_stats_list[-1].epoch_secs
         self.start_datetime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.epoch_start))
         self.finish_datetime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.epoch_finish))
-
-
 
     def __parse_file(self):
         f = open(self.results_file_name, 'rb')
@@ -300,7 +305,6 @@ class Results(object):
         return resp_stats_list
 
 
-
 class ResponseStats(object):
     def __init__(self, request_num, elapsed_time, epoch_secs, user_group_name, trans_time, error, custom_timers):
         self.request_num = request_num
@@ -310,7 +314,6 @@ class ResponseStats(object):
         self.trans_time = trans_time
         self.error = error
         self.custom_timers = custom_timers
-
 
 
 def split_series(points, interval):
@@ -323,11 +326,9 @@ def split_series(points, interval):
     return series
 
 
-
 def average(seq):
     avg = (float(sum(seq)) / len(seq))
     return avg
-
 
 
 def standard_dev(seq):
@@ -340,13 +341,10 @@ def standard_dev(seq):
     return stdev
 
 
-
 def percentile(seq, percentile):
     i = int(len(seq) * (percentile / 100.0))
     seq.sort()
     return seq[i]
-
-
 
 
 if __name__ == '__main__':

--- a/multimechanize/results.py
+++ b/multimechanize/results.py
@@ -16,9 +16,9 @@ import reportwriterxml
 
 
 def output_results(results_dir, results_file, run_time, rampup, ts_interval, user_group_configs=None,
-                   xml_reports=False):
+                   xml_reports=False, allow_overrun=True):
     invalid_timers = []
-    results = Results(results_dir + results_file, run_time)
+    results = Results(results_dir + results_file, run_time, allow_overrun)
 
     report = reportwriter.Report(results_dir)
 
@@ -256,7 +256,8 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
 
 
 class Results(object):
-    def __init__(self, results_file_name, run_time):
+    def __init__(self, results_file_name, run_time, allow_overrun=True):
+        self.allow_overrun = allow_overrun
         self.results_file_name = results_file_name
         self.run_time = run_time
         self.total_transactions = 0
@@ -303,8 +304,9 @@ class Results(object):
 
             r = ResponseStats(request_num, elapsed_time, epoch_secs, user_group_name, trans_time, error, custom_timers)
 
-            # if elapsed_time < self.run_time:  # drop all times that appear after the last request was sent (incomplete interval)
-            resp_stats_list.append(r)
+            # drop all times that appear after the last request was sent (incomplete interval) unless overrun allowed
+            if self.allow_overrun or elapsed_time < self.run_time:
+                resp_stats_list.append(r)
 
             if error != '':
                 self.total_errors += 1

--- a/multimechanize/results.py
+++ b/multimechanize/results.py
@@ -17,6 +17,7 @@ import reportwriterxml
 
 def output_results(results_dir, results_file, run_time, rampup, ts_interval, user_group_configs=None,
                    xml_reports=False):
+    invalid_timers = []
     results = Results(results_dir + results_file, run_time)
 
     report = reportwriter.Report(results_dir)
@@ -226,6 +227,8 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
             report.write_line('<img src="%s_response_times.png"></img>' % timer_name)
             report.write_line('<h4>Throughput: %s sec time-series</h4>' % ts_interval)
             report.write_line('<img src="%s_throughput.png"></img>' % timer_name)
+        else:
+            invalid_timers.append(timer_name)
 
     ## user group times
     # for user_group_name in sorted(results.uniq_user_group_names):
@@ -243,6 +246,12 @@ def output_results(results_dir, results_file, run_time, rampup, ts_interval, use
     #    print ''
 
     report.write_line('<hr />')
+    if len(invalid_timers) > 0:
+        report.write_line('<h2>Invalid Timers</h2>')
+        report.write_line('<ul>')
+        for t in invalid_timers:
+            report.write_line('<li>' + t + '</li>')
+        report.write_line('</ul>')
     report.write_closing_html()
 
 
@@ -294,8 +303,8 @@ class Results(object):
 
             r = ResponseStats(request_num, elapsed_time, epoch_secs, user_group_name, trans_time, error, custom_timers)
 
-            if elapsed_time < self.run_time:  # drop all times that appear after the last request was sent (incomplete interval)
-                resp_stats_list.append(r)
+            # if elapsed_time < self.run_time:  # drop all times that appear after the last request was sent (incomplete interval)
+            resp_stats_list.append(r)
 
             if error != '':
                 self.total_errors += 1

--- a/multimechanize/utilities/run.py
+++ b/multimechanize/utilities/run.py
@@ -73,7 +73,7 @@ def run_test(project_name, cmd_opts, remote_starter=None):
         remote_starter.output_dir = None
 
     run_time, ramp_up, results_ts_interval, console_logging, progress_bar, results_database, post_run_script, \
-    xml_report, user_group_configs = configure(project_name, cmd_opts)
+    xml_report, user_group_configs, allow_overrun = configure(project_name, cmd_opts)
 
     run_localtime = time.localtime()
     output_dir = '%s/%s/results/results_%s' % (
@@ -140,7 +140,7 @@ def run_test(project_name, cmd_opts, remote_starter=None):
     time.sleep(.2)  # make sure the writer queue is flushed
     print '\n\nanalyzing results...\n'
     results.output_results(output_dir, 'results.csv', run_time, ramp_up, results_ts_interval, user_group_configs,
-                           xml_report)
+                           xml_report, allow_overrun)
     print 'created: %sresults.html\n' % output_dir
     if xml_report:
         print 'created: %sresults.jtl' % output_dir
@@ -174,10 +174,10 @@ def rerun_results(project_name, cmd_opts, results_dir):
     output_dir = '%s/%s/results/%s/' % (cmd_opts.projects_dir, project_name, results_dir)
     saved_config = '%s/config.cfg' % output_dir
     run_time, ramp_up, results_ts_interval, console_logging, progress_bar, results_database, post_run_script, \
-    xml_report, user_group_configs = configure(project_name, cmd_opts, config_file=saved_config)
+    xml_report, user_group_configs, allow_overrun = configure(project_name, cmd_opts, config_file=saved_config)
     print '\n\nanalyzing results...\n'
     results.output_results(output_dir, 'results.csv', run_time, ramp_up, results_ts_interval, user_group_configs,
-                           xml_report)
+                           xml_report, allow_overrun)
     print 'created: %sresults.html\n' % output_dir
     if xml_report:
         print 'created: %sresults.jtl' % output_dir
@@ -187,7 +187,7 @@ def rerun_results(project_name, cmd_opts, results_dir):
 def configure(project_name, cmd_opts, config_file=None):
     # noinspection PyUnusedLocal
     (run_time, ramp_up, results_ts_interval, console_logging, progress_bar, results_database, post_run_script,
-     xml_report, user_group_configs) = (None for i in range(9))
+     xml_report, user_group_configs, allow_overrun) = (None for i in range(10))
     user_group_configs = []
     config = ConfigParser.ConfigParser()
     if config_file is None:
@@ -220,6 +220,10 @@ def configure(project_name, cmd_opts, config_file=None):
                 xml_report = config.getboolean(section, 'xml_report')
             except ConfigParser.NoOptionError:
                 xml_report = False
+            try:
+                allow_overrun = config.getboolean(section, 'allow_overrun')
+            except ConfigParser.NoOptionError:
+                allow_overrun = True
         else:
             threads = config.getint(section, 'threads')
             script = config.get(section, 'script')
@@ -229,7 +233,7 @@ def configure(project_name, cmd_opts, config_file=None):
 
     return (
         run_time, ramp_up, results_ts_interval, console_logging, progress_bar, results_database, post_run_script,
-        xml_report, user_group_configs)
+        xml_report, user_group_configs, allow_overrun)
 
 
 class UserGroupConfig(object):


### PR DESCRIPTION
If a timer completes after the test run time has ended, then result generation fails. This change allows the report to be generated anyway, and will either list timers that could not be graphed, or graph them anyway.

a new config option (defaulted to True) allows the user to control wheter to report results from after the test run finished, or to list these as "Invalid Timers" at the end of the report.